### PR TITLE
Update: Project Images Fit

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -39,7 +39,7 @@
   }
 
   .accordion-custom {
-    @apply flex flex-col rounded-md bg-dark-800/65 border border-dark-700 hover:border-dark-700 hover:duration-300 px-4 pt-3 pb-4;
+    @apply flex flex-col rounded-md bg-dark-800/65 border border-dark-700 hover:border-dark-700 hover:duration-300 px-4 pt-3 pb-4 max-md:px-3 max-md:py-2;
   }
   .accordion-content-custom {
     @apply pb-0 py-3 px-4 max-md:px-3;

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -18,7 +18,7 @@ const ProjectCard = ({
 }) => {
   const renderImage = () => {
     return (
-      <div className="relative ml-4 w-[500px] min-w-20 pt-1 max-md-projects:mx-0 max-md-projects:mb-3 max-md-projects:mt-2 max-md-projects:flex max-md-projects:w-full max-md-projects:flex-wrap max-md-projects:justify-center">
+      <div className="relative ml-4 w-[500px] min-w-20 pt-1 max-md-projects:mx-0 max-md-projects:my-2 max-md-projects:flex max-md-projects:w-full max-md-projects:flex-wrap max-md-projects:justify-center">
         <Image
           alt={project.altText}
           src={project.coverImage}

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -18,7 +18,7 @@ const ProjectCard = ({
 }) => {
   const renderNoCommitsOrNoPRsDiv = (type: string) => {
     return (
-      <div className="rounded-md bg-dark-800/65 border border-dark-800 p-4">
+      <div className="rounded-md border border-dark-800 bg-dark-800/65 p-4">
         <p className="text-sm font-light text-slate-300 max-sm:text-[13px] 3xl:text-base">
           No {type} created this year
         </p>
@@ -27,8 +27,8 @@ const ProjectCard = ({
   };
 
   return (
-    <section className="group flex gap-x-9 gap-y-4 rounded-lg bg-slate-900/50 p-6 pl-3 max-md:p-6 max-md:flex-col max-md:gap-y-3">
-      <div className="relative ml-4 w-80 min-w-20 content-center pt-1 max-md:mx-0  max-md:mt-1 max-md:w-full">
+    <section className="group flex gap-x-9 gap-y-4 rounded-lg bg-slate-900/50 p-6 pl-3 max-md-projects:flex-col max-md-projects:gap-y-3 max-md-projects:p-6">
+      <div className="relative ml-4 w-[500px] min-w-20 pt-1 max-md-projects:mx-0 max-md-projects:mt-1 max-md-projects:flex max-md-projects:w-full max-md-projects:flex-wrap max-md-projects:justify-center">
         <Image
           alt={project.altText}
           src={project.coverImage}
@@ -36,9 +36,9 @@ const ProjectCard = ({
           placeholder="blur"
         />
       </div>
-      <div className="flex w-3/4 max-w-[1000px] flex-col justify-between gap-y-4 max-md:-order-1 max-md:w-full max-md:gap-y-3">
-        <section className="flex flex-col gap-y-4 max-md:flex-row max-md:items-center max-md:justify-between max-md:gap-y-2.5 max-sm:flex-col">
-          <h1 className="text-wrap text-sm font-medium text-slate-100 duration-300 group-hover:text-corral max-md:text-base max-sm:text-center max-sm:text-sm 3xl:text-lg">
+      <div className="flex w-3/4 max-w-[1000px] flex-col justify-between gap-y-4 max-md-projects:-order-1 max-md-projects:w-full max-md-projects:gap-y-3">
+        <section className="flex flex-col gap-y-4 max-md-projects:flex-row max-md-projects:items-center max-md-projects:justify-between max-md-projects:gap-y-2.5 max-sm:flex-col">
+          <h1 className="text-wrap text-sm font-medium text-slate-100 duration-300 group-hover:text-corral max-md-projects:text-base max-sm:text-center max-sm:text-sm 3xl:text-lg">
             {project.title}
           </h1>
           <div className="flex gap-x-4">
@@ -49,7 +49,7 @@ const ProjectCard = ({
           </div>
         </section>
 
-        <p className="text-sm font-light text-slate-300 max-md:text-center max-sm:text-sm 3xl:text-base">
+        <p className="text-sm font-light text-slate-300 max-md-projects:text-center max-sm:text-sm 3xl:text-base">
           {project.description}{' '}
           {project.demoCredentials && (
             <p className="mt-2">
@@ -69,7 +69,7 @@ const ProjectCard = ({
           )}
         </p>
 
-        <div className="flex flex-wrap gap-x-3 gap-y-2 max-md:justify-center mb-2">
+        <div className="mb-2 flex flex-wrap gap-x-3 gap-y-2 max-md-projects:justify-center">
           {project.tags.map((tag) => {
             return <Tag key={tag} text={tag} />;
           })}

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -26,9 +26,9 @@ const ProjectCard = ({
     );
   };
 
-  return (
-    <section className="group flex gap-x-9 gap-y-4 rounded-lg bg-slate-900/50 p-6 pl-3 max-md-projects:flex-col max-md-projects:gap-y-3 max-md-projects:p-6">
-      <div className="relative ml-4 w-[500px] min-w-20 pt-1 max-md-projects:mx-0 max-md-projects:mt-1 max-md-projects:flex max-md-projects:w-full max-md-projects:flex-wrap max-md-projects:justify-center">
+  const renderImage = () => {
+    return (
+      <div className="relative ml-4 w-[500px] min-w-20 pt-1 max-md-projects:mx-0 max-md-projects:mb-4 max-md-projects:mt-3 max-md-projects:flex max-md-projects:w-full max-md-projects:flex-wrap max-md-projects:justify-center">
         <Image
           alt={project.altText}
           src={project.coverImage}
@@ -36,7 +36,15 @@ const ProjectCard = ({
           placeholder="blur"
         />
       </div>
-      <div className="flex w-3/4 max-w-[1000px] flex-col justify-between gap-y-4 max-md-projects:-order-1 max-md-projects:w-full max-md-projects:gap-y-3">
+    );
+  };
+
+  return (
+    <section className="group flex gap-x-9 gap-y-4 rounded-lg bg-slate-900/50 p-6 pl-3 max-md-projects:flex-col max-md-projects:gap-y-3 max-md-projects:p-6">
+      <div className="max-md-projects:hidden md-projects:block">
+        {renderImage()}
+      </div>
+      <div className="flex w-3/4 max-w-[1000px] flex-col justify-between gap-y-4 max-md-projects:w-full max-md-projects:gap-y-3">
         <section className="flex flex-col gap-y-4 max-md-projects:flex-row max-md-projects:items-center max-md-projects:justify-between max-md-projects:gap-y-2.5 max-sm:flex-col">
           <h1 className="text-wrap text-sm font-medium text-slate-100 duration-300 group-hover:text-corral max-md-projects:text-base max-sm:text-center max-sm:text-sm 3xl:text-lg">
             {project.title}
@@ -48,6 +56,8 @@ const ProjectCard = ({
             <LinkWithIcon label="Source Code" href={project.githubLink} />
           </div>
         </section>
+
+        <div className="md-projects:hidden">{renderImage()}</div>
 
         <p className="text-sm font-light text-slate-300 max-md-projects:text-center max-sm:text-sm 3xl:text-base">
           {project.description}{' '}

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -16,25 +16,25 @@ const ProjectCard = ({
   pullRequests: RepoPR[];
   commits: RepoCommit[];
 }) => {
-  const renderNoCommitsOrNoPRsDiv = (type: string) => {
-    return (
-      <div className="rounded-md border border-dark-800 bg-dark-800/65 p-4">
-        <p className="text-sm font-light text-slate-300 max-sm:text-[13px] 3xl:text-base">
-          No {type} created this year
-        </p>
-      </div>
-    );
-  };
-
   const renderImage = () => {
     return (
-      <div className="relative ml-4 w-[500px] min-w-20 pt-1 max-md-projects:mx-0 max-md-projects:mb-4 max-md-projects:mt-3 max-md-projects:flex max-md-projects:w-full max-md-projects:flex-wrap max-md-projects:justify-center">
+      <div className="relative ml-4 w-[500px] min-w-20 pt-1 max-md-projects:mx-0 max-md-projects:mb-3 max-md-projects:mt-2 max-md-projects:flex max-md-projects:w-full max-md-projects:flex-wrap max-md-projects:justify-center">
         <Image
           alt={project.altText}
           src={project.coverImage}
           className="rounded-lg"
           placeholder="blur"
         />
+      </div>
+    );
+  };
+
+  const renderNoCommitsOrNoPRsDiv = (type: string) => {
+    return (
+      <div className="rounded-md border border-dark-800 bg-dark-800/65 p-4">
+        <p className="text-sm font-light text-slate-300 max-sm:text-[13px] 3xl:text-base">
+          No {type} created this year
+        </p>
       </div>
     );
   };

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -18,7 +18,7 @@ const Projects = ({
       initial={{ opacity: 0 }}
       whileInView={{ opacity: 1 }}
       transition={{ duration: 0.8 }}
-      className="mx-7 my-32 flex flex-col gap-y-8 max-md:my-12 max-md:gap-y-10"
+      className="mx-7 my-32 flex flex-col gap-y-8 max-md-projects:mx-5 max-md-projects:my-11 max-md-projects:gap-y-10"
     >
       {projects.map((project) => {
         const repoName = project.githubLink.split('/').pop();

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -24,6 +24,7 @@ const config = {
         'xs-345': '345px',
         'xs-362': '362px',
         md: '820px',
+        'md-projects': '1180px',
         '2xl': '1400px',
         '3xl': '2000px',
       },


### PR DESCRIPTION
### Updates
- Added a new `md` breakpoint for the projects tab
- Moved project images to top of div rather than centered vertically for screens large than 1100px
- Switch column-centered layout at new `1100px` breakpoint rather than original `820px` breakpoint
- Updated project image order based on screen size
- Updated padding and margins for better mobile fit